### PR TITLE
Vadymk/escaping underline bug

### DIFF
--- a/src/DataStore/src/DataStore/ConditionBuilder/SqlConditionBuilder.php
+++ b/src/DataStore/src/DataStore/ConditionBuilder/SqlConditionBuilder.php
@@ -146,10 +146,8 @@ class SqlConditionBuilder extends ConditionBuilderAbstract
 
     private function containsNodeSpecSymbolsEcranation(string $value)
     {
-        if ((str_contains($value, '\\')) && (str_contains($value, '%') || str_contains($value, '_'))) {
-            throw new DataStoreException('Rql cannot contains backspace AND % OR _ in one request');
-        }
-        $value = str_replace(['%', '_'], ['\%', '\_'], $value);
+        $value = preg_replace('~(?<!\\\\)%~', '\\\\%', $value); // %  -> \%
+        $value = preg_replace('~(?<!\\\\)_~',  '\\\\_', $value); // _  -> \_
         return $value;
     }
 

--- a/src/DataStore/src/DataStore/ConditionBuilder/SqlConditionBuilder.php
+++ b/src/DataStore/src/DataStore/ConditionBuilder/SqlConditionBuilder.php
@@ -147,7 +147,7 @@ class SqlConditionBuilder extends ConditionBuilderAbstract
     private function containsNodeSpecSymbolsEcranation(string $value)
     {
         $value = preg_replace('~(?<!\\\\)%~', '\\\\%', $value); // %  -> \%
-        $value = preg_replace('~(?<!\\\\)_~',  '\\\\_', $value); // _  -> \_
+        $value = preg_replace('~(?<!\\\\)_~', '\\\\_', $value); // _  -> \_
         return $value;
     }
 


### PR DESCRIPTION
Fix bug: URL-encoded strings with % and \ symbols in one request incorrectly trigger validation error