### PR TITLE
Vadymk/escaping underline bug 7.2

### DIFF
--- a/src/DataStore/src/DataStore/ConditionBuilder/SqlConditionBuilder.php
+++ b/src/DataStore/src/DataStore/ConditionBuilder/SqlConditionBuilder.php
@@ -136,7 +136,7 @@ class SqlConditionBuilder extends ConditionBuilderAbstract
     private function containsNodeSpecSymbolsEcranation(string $value)
     {
         $value = preg_replace('~(?<!\\\\)%~', '\\\\%', $value); // %  -> \%
-        $value = preg_replace('~(?<!\\\\)_~',  '\\\\_', $value); // _  -> \_
+        $value = preg_replace('~(?<!\\\\)_~', '\\\\_', $value); // _  -> \_
         return $value;
     }
 

--- a/src/DataStore/src/DataStore/ConditionBuilder/SqlConditionBuilder.php
+++ b/src/DataStore/src/DataStore/ConditionBuilder/SqlConditionBuilder.php
@@ -135,15 +135,9 @@ class SqlConditionBuilder extends ConditionBuilderAbstract
 
     private function containsNodeSpecSymbolsEcranation(string $value)
     {
-        $hasBackslash = strpos($value, '\\') !== false;
-        $hasPercent   = strpos($value, '%') !== false;
-        $hasUnderscore= strpos($value, '_') !== false;
-
-        if ($hasBackslash && ($hasPercent || $hasUnderscore)) {
-            throw new DataStoreException('RQL cannot contain backslash together with % or _ in one request');
-        }
-
-        return str_replace(['%', '_'], ['\\%', '\\_'], $value);
+        $value = preg_replace('~(?<!\\\\)%~', '\\\\%', $value); // %  -> \%
+        $value = preg_replace('~(?<!\\\\)_~',  '\\\\_', $value); // _  -> \_
+        return $value;
     }
 
     /**

--- a/test/functional/DataStore/DataStore/DbTable/ContainsUnderScoreTest.php
+++ b/test/functional/DataStore/DataStore/DbTable/ContainsUnderScoreTest.php
@@ -47,14 +47,13 @@ final class ContainsUnderScoreTest extends TestCase
             'profiler' => $this->profiler,
             'options'  => [
                 \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
-                \PDO::ATTR_EMULATE_PREPARES => false, // см. примечание ниже
+                \PDO::ATTR_EMULATE_PREPARES => false,
                 \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
             ],
         ]);
 
-        // схема для MySQL
         $this->adapter->query(
-            'CREATE TABLE IF NOT EXISTS amazon_shipping_templates (
+            'CREATE TABLE IF NOT EXISTS amazon_shipping_templates_underscore_test (
             id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
             template_code    VARCHAR(191) NOT NULL,
             shipping_service VARCHAR(191) NOT NULL,
@@ -63,11 +62,14 @@ final class ContainsUnderScoreTest extends TestCase
             $this->adapter::QUERY_MODE_EXECUTE
         );
 
-        $gw = new \Laminas\Db\TableGateway\TableGateway('amazon_shipping_templates', $this->adapter);
+        $gw = new \Laminas\Db\TableGateway\TableGateway('amazon_shipping_templates_underscore_test', $this->adapter);
         $this->ds = new \rollun\datastore\DataStore\DbTable($gw, 'id');
 
-        // data to insert
+        $this->adapter->query('TRUNCATE TABLE amazon_shipping_templates_underscore_test', $this->adapter::QUERY_MODE_EXECUTE);
+
+        // data to insert - covering various edge cases with % and _ symbols
         $rows = [
+            // Original underscore test data
             ['template_code' => 'PU_DS_NV__2025-03-20',         'shipping_service' => 'Standard Shipping', 'mln' => 'test'],
             ['template_code' => 'PU_DS_NV_NY_TX_WI__2025-03-24', 'shipping_service' => 'Standard Shipping', 'mln' => 'test'],
             ['template_code' => 'PU_DS_NV__2025-03-20',         'shipping_service' => 'Free Economy', 'mln' => 'test'],
@@ -76,6 +78,21 @@ final class ContainsUnderScoreTest extends TestCase
             ['template_code' => 'PU_DS_NV_NY_TX_WI__2025-03-24', 'shipping_service' => 'Expedited Shipping', 'mln' => 'test'],
             ['template_code' => '__PU_DS_NV__NY_TX_WI__2025-03-24', 'shipping_service' => 'Expedited Shipping', 'mln' => 'test'],
             ['template_code' => 'XXPU_DS_NV_NY_TX_WI__2025-03-24', 'shipping_service' => 'Expedited Shipping', 'mln' => 'test'],
+
+            // Test data for percent symbol scenarios
+            ['template_code' => 'test%value_2025',              'shipping_service' => 'Express', 'mln' => 'percent_test'],
+            ['template_code' => 'test_percent_value_2025',      'shipping_service' => 'Express', 'mln' => 'percent_test'],
+            ['template_code' => 'testXvalue_2025',              'shipping_service' => 'Express', 'mln' => 'percent_test'],
+
+            // Test data for combined % and _ scenarios
+            ['template_code' => 'order_%_status_active',        'shipping_service' => 'Premium', 'mln' => 'combined_test'],
+            ['template_code' => 'order_XX_status_active',       'shipping_service' => 'Premium', 'mln' => 'combined_test'],
+            ['template_code' => 'order_pending_status_active',  'shipping_service' => 'Premium', 'mln' => 'combined_test'],
+
+            // URL-encoded scenario test data
+            ['template_code' => '"#dont_sell#"',                'shipping_service' => 'Special', 'mln' => 'url_test'],
+            ['template_code' => '"#dont_sell_more#"',           'shipping_service' => 'Special', 'mln' => 'url_test'],
+            ['template_code' => '"#dontXsell#"',                'shipping_service' => 'Special', 'mln' => 'url_test'],
         ];
         foreach ($rows as $row) {
             $this->ds->create($row);
@@ -87,7 +104,6 @@ final class ContainsUnderScoreTest extends TestCase
      */
     public function testContainsBuildsWithEscapedUnderscore(): void
     {
-        $this->markTestSkipped();
         $this->ds->query(new RqlQuery('contains(template_code,string:PU_DS_NV__)'));
 
         $profiles = $this->profiler->getProfiles();
@@ -175,12 +191,107 @@ final class ContainsUnderScoreTest extends TestCase
     }
 
     /**
+     * Test that percent symbol is properly escaped in contains queries.
+     * Should escape % as \% to prevent SQL wildcard matching.
+     */
+    public function testContainsEscapesPercentSymbol(): void
+    {
+        // Create query programmatically to avoid RQL parser issues with %
+        $query = new RqlQuery();
+        $query->setQuery(new ContainsNode('template_code', 'test%value'));
+        $this->ds->query($query);
+
+        $profiles = $this->profiler->getProfiles();
+        $this->assertNotEmpty($profiles, 'Profiler must contains at least 1 SQL-request.');
+
+        $last = end($profiles);
+        $sql = (string) ($last['sql'] ?? '');
+
+        $this->assertNotEmpty($sql, 'Last SQL must not be empty.');
+        $this->assertTrue(str_contains($sql, 'LIKE'), "SQL must contain LIKE. Received: {$sql}");
+
+        // Check that % is escaped as \%
+        $this->assertTrue(str_contains($sql, '%test\%value%'), "SQL should contain escaped percent: {$sql}");
+
+        // Check that only exact matches are found (not wildcard matches)
+        $query2 = new RqlQuery();
+        $query2->setQuery(new ContainsNode('template_code', 'test%value'));
+        $rows = $this->materialize($this->ds->query($query2));
+        $this->assertCount(1, $rows, 'Should find exactly 1 row with test%value');
+        $this->assertSame('test%value_2025', $rows[0]['template_code']);
+    }
+
+    /**
+     * Test that both percent and underscore symbols are properly escaped together.
+     * Should escape both % as \% and _ as \_ to prevent SQL wildcard matching.
+     */
+    public function testContainsEscapesBothPercentAndUnderscore(): void
+    {
+        // Create query programmatically to avoid RQL parser issues with %
+        $query = new RqlQuery();
+        $query->setQuery(new ContainsNode('template_code', 'order_%_status'));
+        $this->ds->query($query);
+
+        $profiles = $this->profiler->getProfiles();
+        $this->assertNotEmpty($profiles, 'Profiler must contains at least 1 SQL-request.');
+
+        $last = end($profiles);
+        $sql = (string) ($last['sql'] ?? '');
+
+        $this->assertNotEmpty($sql, 'Last SQL must not be empty.');
+        $this->assertTrue(str_contains($sql, 'LIKE'), "SQL must contain LIKE. Received: {$sql}");
+
+        // Check that both % and _ are escaped
+        $this->assertTrue(str_contains($sql, '%order\_\%\_status%'), "SQL should contain both escaped symbols: {$sql}");
+
+        // Check that only exact matches are found (not wildcard matches)
+        $query2 = new RqlQuery();
+        $query2->setQuery(new ContainsNode('template_code', 'order_%_status'));
+        $rows = $this->materialize($this->ds->query($query2));
+        $this->assertCount(1, $rows, 'Should find exactly 1 row with order_%_status');
+        $this->assertSame('order_%_status_active', $rows[0]['template_code']);
+    }
+
+    /**
+     * Test edge case with only special characters.
+     * Should properly escape and find exact matches.
+     */
+    public function testContainsWithOnlySpecialCharacters(): void
+    {
+        // Add test data with only special chars
+        $this->ds->create(['template_code' => '_%', 'shipping_service' => 'Special', 'mln' => 'edge_case']);
+        $this->ds->create(['template_code' => '_X', 'shipping_service' => 'Special', 'mln' => 'edge_case']);
+
+        // Create query programmatically to avoid RQL parser issues with %
+        $query = new RqlQuery();
+        $query->setQuery(new ContainsNode('template_code', '_%'));
+        $this->ds->query($query);
+
+        $profiles = $this->profiler->getProfiles();
+        $last = end($profiles);
+        $sql = (string) ($last['sql'] ?? '');
+
+        // Check proper escaping
+        $this->assertTrue(str_contains($sql, '%\_\%%'), "SQL should escape both characters: {$sql}");
+
+        // Check exact match count - only '_%' should be found
+        $query2 = new RqlQuery();
+        $query2->setQuery(new ContainsNode('template_code', '_%'));
+        $rows = $this->materialize($this->ds->query($query2));
+
+        // Both rows should be found: '_%' and 'order_%_status_active' (contains '_%')
+        $foundCodes = array_column($rows, 'template_code');
+        $this->assertCount(2, $rows, 'Should find 2 rows containing _%' . '. Found: ' . implode(', ', $foundCodes));
+        $this->assertContains('_%', $foundCodes);
+        $this->assertContains('order_%_status_active', $foundCodes);
+    }
+
+    /**
      * Test that verifies the fix works correctly.
      * After fix, URL-encoded strings should be handled properly.
      */
-    public function testUrlEncodedStringAfterFix(): void
+    public function testContainsPrepareValuesCorrectWithSpecSymbolsAndMysqlQuote(): void
     {
-        $this->markTestSkipped();
         // This should work after fix - URL-encoded % should not be treated as SQL wildcard
         $this->ds->query(new RqlQuery('contains(template_code,string:%22%23dont%5Fsell%23)'));
 
@@ -197,16 +308,11 @@ final class ContainsUnderScoreTest extends TestCase
         );
 
         // Should escape _ properly in the decoded string
-        $this->assertTrue(str_contains($sql, '%"#dont\_sell#%'));
-    }
+        $this->assertTrue(str_contains($sql, '%\"#dont\_sell#%'));
 
-    public function testPersonal()
-    {
-        $rqlString = 'contains(tags,string:%22%23dont%5Fsell%23)';
-        $this->expectException(DataStoreException::class);
-//        $this->expectExceptionMessage("Can't build sql from rql query");
-        $query = new RqlQuery($rqlString);
-        $this->expectException(InvalidQueryException::class);
-        $this->ds->query($query);
+        // Check that only exact matches are found
+        $rows = $this->materialize($this->ds->query(new RqlQuery('contains(template_code,string:%22%23dont%5Fsell%23)')));
+        $this->assertCount(1, $rows, 'Should find exactly 1 row with "#dont_sell#"');
+        $this->assertSame('"#dont_sell#"', $rows[0]['template_code']);
     }
 }

--- a/test/functional/DataStore/DataStore/DbTable/ContainsUnderScoreTest.php
+++ b/test/functional/DataStore/DataStore/DbTable/ContainsUnderScoreTest.php
@@ -114,11 +114,11 @@ final class ContainsUnderScoreTest extends TestCase
 
         $this->assertNotEmpty($sql, 'Last SQL must not be empty.');
         $this->assertTrue(
-            str_contains($sql, 'LIKE'),
+            strpos($sql, 'LIKE') !== false,
             "Last SQL must contains LIKE. Received: {$sql}"
         );
 
-        $this->assertTrue(str_contains($sql, "%PU\_DS\_NV\_\_%"));
+        $this->assertTrue(strpos($sql, "%PU\_DS\_NV\_\_%") !== false);
     }
 
     public function testEqMatchReturnsRows(): void
@@ -208,10 +208,10 @@ final class ContainsUnderScoreTest extends TestCase
         $sql = (string) ($last['sql'] ?? '');
 
         $this->assertNotEmpty($sql, 'Last SQL must not be empty.');
-        $this->assertTrue(str_contains($sql, 'LIKE'), "SQL must contain LIKE. Received: {$sql}");
+        $this->assertTrue(strpos($sql, 'LIKE') !== false, "SQL must contain LIKE. Received: {$sql}");
 
         // Check that % is escaped as \%
-        $this->assertTrue(str_contains($sql, '%test\%value%'), "SQL should contain escaped percent: {$sql}");
+        $this->assertTrue(strpos($sql, '%test\%value%') !== false, "SQL should contain escaped percent: {$sql}");
 
         // Check that only exact matches are found (not wildcard matches)
         $query2 = new RqlQuery();
@@ -239,10 +239,10 @@ final class ContainsUnderScoreTest extends TestCase
         $sql = (string) ($last['sql'] ?? '');
 
         $this->assertNotEmpty($sql, 'Last SQL must not be empty.');
-        $this->assertTrue(str_contains($sql, 'LIKE'), "SQL must contain LIKE. Received: {$sql}");
+        $this->assertTrue(strpos($sql, 'LIKE') !== false, "SQL must contain LIKE. Received: {$sql}");
 
         // Check that both % and _ are escaped
-        $this->assertTrue(str_contains($sql, '%order\_\%\_status%'), "SQL should contain both escaped symbols: {$sql}");
+        $this->assertTrue(strpos($sql, '%order\_\%\_status%') !== false, "SQL should contain both escaped symbols: {$sql}");
 
         // Check that only exact matches are found (not wildcard matches)
         $query2 = new RqlQuery();
@@ -272,7 +272,7 @@ final class ContainsUnderScoreTest extends TestCase
         $sql = (string) ($last['sql'] ?? '');
 
         // Check proper escaping
-        $this->assertTrue(str_contains($sql, '%\_\%%'), "SQL should escape both characters: {$sql}");
+        $this->assertTrue(strpos($sql, '%\_\%%') !== false, "SQL should escape both characters: {$sql}");
 
         // Check exact match count - only '_%' should be found
         $query2 = new RqlQuery();
@@ -303,12 +303,12 @@ final class ContainsUnderScoreTest extends TestCase
 
         $this->assertNotEmpty($sql, 'Last SQL must not be empty.');
         $this->assertTrue(
-            str_contains($sql, 'LIKE'),
+            strpos($sql, 'LIKE') !== false,
             "Last SQL must contains LIKE. Received: {$sql}"
         );
 
         // Should escape _ properly in the decoded string
-        $this->assertTrue(str_contains($sql, '%\"#dont\_sell#%'));
+        $this->assertTrue(strpos($sql, '%\"#dont\_sell#%') !== false);
 
         // Check that only exact matches are found
         $rows = $this->materialize($this->ds->query(new RqlQuery('contains(template_code,string:%22%23dont%5Fsell%23)')));

--- a/test/functional/DataStore/DataStore/DbTable/ContainsUnderScoreTest.php
+++ b/test/functional/DataStore/DataStore/DbTable/ContainsUnderScoreTest.php
@@ -32,26 +32,39 @@ final class ContainsUnderScoreTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->profiler = new Profiler();
-        $this->adapter = new Adapter([
-            'driver'   => 'Pdo_Sqlite',
-            'database' => ':memory:',
+        $this->profiler = new \Laminas\Db\Adapter\Profiler\Profiler();
+
+        $this->adapter = new \Laminas\Db\Adapter\Adapter([
+            'driver'   => 'Pdo_Mysql',
+            'dsn'      => sprintf(
+                'mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4',
+                getenv('DB_HOST') ?: 'mysql',
+                getenv('DB_PORT') ?: '3306',
+                getenv('DB_NAME') ?: 'app_test',
+            ),
+            'username' => getenv('DB_USER') ?: 'app',
+            'password' => getenv('DB_PASS') ?: 'secret',
             'profiler' => $this->profiler,
-            'options'  => [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION],
+            'options'  => [
+                \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
+                \PDO::ATTR_EMULATE_PREPARES => false, // см. примечание ниже
+                \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+            ],
         ]);
 
+        // схема для MySQL
         $this->adapter->query(
-            'CREATE TABLE amazon_shipping_templates (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                template_code TEXT NOT NULL,
-                shipping_service TEXT NOT NULL,
-                mln TEXT NOT NULL
-            )',
+            'CREATE TABLE IF NOT EXISTS amazon_shipping_templates (
+            id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+            template_code    VARCHAR(191) NOT NULL,
+            shipping_service VARCHAR(191) NOT NULL,
+            mln              VARCHAR(191) NOT NULL
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci',
             $this->adapter::QUERY_MODE_EXECUTE
         );
 
-        $gw = new TableGateway('amazon_shipping_templates', $this->adapter);
-        $this->ds = new DbTable($gw, 'id');
+        $gw = new \Laminas\Db\TableGateway\TableGateway('amazon_shipping_templates', $this->adapter);
+        $this->ds = new \rollun\datastore\DataStore\DbTable($gw, 'id');
 
         // data to insert
         $rows = [
@@ -74,6 +87,7 @@ final class ContainsUnderScoreTest extends TestCase
      */
     public function testContainsBuildsWithEscapedUnderscore(): void
     {
+        $this->markTestSkipped();
         $this->ds->query(new RqlQuery('contains(template_code,string:PU_DS_NV__)'));
 
         $profiles = $this->profiler->getProfiles();
@@ -188,10 +202,11 @@ final class ContainsUnderScoreTest extends TestCase
 
     public function testPersonal()
     {
-        $rqlString = 'select(count(mln))&and(not(eq(ct%5Fquantity,0)),eq(ct%5Factive,1),eq(mp%5Fstatus,string:inactive),not(contains(tags,string:%22%23dont%5Fsell%23)))';
-        $query = new RqlQuery($rqlString);
-        $this->ds->query($query);
+        $rqlString = 'contains(tags,string:%22%23dont%5Fsell%23)';
         $this->expectException(DataStoreException::class);
-        $this->expectExceptionMessage('Rql cannot contains backspace AND % OR _ in one request');
+//        $this->expectExceptionMessage("Can't build sql from rql query");
+        $query = new RqlQuery($rqlString);
+        $this->expectException(InvalidQueryException::class);
+        $this->ds->query($query);
     }
 }

--- a/test/functional/DataStore/DataStore/DbTable/ContainsUnderScoreTest.php
+++ b/test/functional/DataStore/DataStore/DbTable/ContainsUnderScoreTest.php
@@ -32,15 +32,15 @@ final class ContainsUnderScoreTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->profiler = new \Laminas\Db\Adapter\Profiler\Profiler();
+        $this->profiler = new Profiler();
 
-        $this->adapter = new \Laminas\Db\Adapter\Adapter([
+        $this->adapter = new Adapter([
             'driver'   => 'Pdo_Mysql',
             'dsn'      => sprintf(
                 'mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4',
                 getenv('DB_HOST') ?: 'mysql',
                 getenv('DB_PORT') ?: '3306',
-                getenv('DB_NAME') ?: 'app_test',
+                getenv('DB_NAME') ?: 'app_test'
             ),
             'username' => getenv('DB_USER') ?: 'app',
             'password' => getenv('DB_PASS') ?: 'secret',
@@ -62,8 +62,8 @@ final class ContainsUnderScoreTest extends TestCase
             $this->adapter::QUERY_MODE_EXECUTE
         );
 
-        $gw = new \Laminas\Db\TableGateway\TableGateway('amazon_shipping_templates_underscore_test', $this->adapter);
-        $this->ds = new \rollun\datastore\DataStore\DbTable($gw, 'id');
+        $gw = new TableGateway('amazon_shipping_templates_underscore_test', $this->adapter);
+        $this->ds = new DbTable($gw, 'id');
 
         $this->adapter->query('TRUNCATE TABLE amazon_shipping_templates_underscore_test', $this->adapter::QUERY_MODE_EXECUTE);
 

--- a/test/functional/DataStore/DataStore/DbTable/ContainsUnderScoreTest.php
+++ b/test/functional/DataStore/DataStore/DbTable/ContainsUnderScoreTest.php
@@ -304,7 +304,7 @@ final class ContainsUnderScoreTest extends TestCase
         $this->assertNotEmpty($sql, 'Last SQL must not be empty.');
         $this->assertTrue(
             str_contains($sql, 'LIKE'),
-            "Last SQL must contains LIKE. Received: {$sql}",
+            "Last SQL must contains LIKE. Received: {$sql}"
         );
 
         // Should escape _ properly in the decoded string


### PR DESCRIPTION
Fix bug: URL-encoded strings with % and \ symbols in one request incorrectly trigger validation error